### PR TITLE
feat: filter by part-of label

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ spec:
         - "100"
         - -v
         - debug
+        - --part-of
+        - < APP NAME >
         image: hpa-scale-to-zero:1
         imagePullPolicy: Always
         name: hpa-scale-to-zero

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ else:
 
 ### Running
 ```bash
-zero-scale --namespace <THE NAMESPACE> --hpa <THE HPA NAME> --metric-name "prometheus.googleapis.com|resque_jobs_in_queue|gauge" -v debug --period 2 --deployment <DEPLOYMENT NAME>
+zero-scale --namespace <THE NAMESPACE> --hpa <THE HPA NAME> --metric-name "prometheus.googleapis.com|resque_jobs_in_queue|gauge" -v debug --period 2 --deployment <DEPLOYMENT NAME> --part-of < APP NAME >
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ spec:
         - "100"
         - -v
         - debug
-        - --part-of
-        - < APP NAME >
+        - --filter-label
+        - < LABEL=VALUE >
         image: hpa-scale-to-zero:1
         imagePullPolicy: Always
         name: hpa-scale-to-zero
@@ -138,7 +138,7 @@ else:
 
 ### Running
 ```bash
-zero-scale --namespace <THE NAMESPACE> --hpa <THE HPA NAME> --metric-name "prometheus.googleapis.com|resque_jobs_in_queue|gauge" -v debug --period 2 --deployment <DEPLOYMENT NAME> --part-of < APP NAME >
+zero-scale --namespace <THE NAMESPACE> --hpa <THE HPA NAME> --metric-name "prometheus.googleapis.com|resque_jobs_in_queue|gauge" -v debug --period 2 --deployment <DEPLOYMENT NAME> --filter-label < LABEL=VALUE >
 ```
 
 

--- a/zero_scale/app/scale_to_zero.py
+++ b/zero_scale/app/scale_to_zero.py
@@ -22,6 +22,7 @@ class ScaleToZero:
         self.hpa_name = params['hpa_name']
         self.metric_name = params['metric_name']
         self.deployment_name = params['deployment_name']
+        self.part_of = params['part_of']
 
         self.logger.debug(f'Initialized with params: %s', params)
 
@@ -38,9 +39,7 @@ class ScaleToZero:
 
     @retry(retry=retry_if_exception_type(ApiException))
     def current_metric_value(self):
-
-        metrics_url='/apis/custom.metrics.k8s.io/v1beta1/namespaces/{}/pods/*/{}'.format(self.namespace, self.metric_name)
-
+        metrics_url='/apis/custom.metrics.k8s.io/v1beta1/namespaces/{}/pods/*/{}?labelSelector=app.kubernetes.io/part-of={}' .format(self.namespace, self.metric_name , self.part_of)
         try:
             res = json.loads(self.client_api.call_api(metrics_url, 'GET', auth_settings=['BearerToken'], _preload_content=False)[0].data.decode('utf-8'))
             value = [element for element in res['items'] if element["metricName"] == self.metric_name][0]['value']

--- a/zero_scale/app/scale_to_zero.py
+++ b/zero_scale/app/scale_to_zero.py
@@ -22,7 +22,7 @@ class ScaleToZero:
         self.hpa_name = params['hpa_name']
         self.metric_name = params['metric_name']
         self.deployment_name = params['deployment_name']
-        self.part_of = params['part_of']
+        self.filter_label = params['filter_label']
 
         self.logger.debug(f'Initialized with params: %s', params)
 
@@ -39,7 +39,7 @@ class ScaleToZero:
 
     @retry(retry=retry_if_exception_type(ApiException))
     def current_metric_value(self):
-        metrics_url='/apis/custom.metrics.k8s.io/v1beta1/namespaces/{}/pods/*/{}?labelSelector=app.kubernetes.io/part-of={}' .format(self.namespace, self.metric_name , self.part_of)
+        metrics_url='/apis/custom.metrics.k8s.io/v1beta1/namespaces/{}/pods/*/{}{}' .format(self.namespace, self.metric_name , f'?labelSelector=app.kubernetes.io/{self.filter_label}' if self.filter_label else '')
         try:
             res = json.loads(self.client_api.call_api(metrics_url, 'GET', auth_settings=['BearerToken'], _preload_content=False)[0].data.decode('utf-8'))
             value = [element for element in res['items'] if element["metricName"] == self.metric_name][0]['value']

--- a/zero_scale/cli.py
+++ b/zero_scale/cli.py
@@ -33,10 +33,10 @@ click_log.basic_config(logger)
 @click.option('-d', '--deployment', 'deployment_name',
               default='default',
               help='The deployment to modify')
-@click.option('-po', '--part-of', 'part_of',
-              help='The part_of value to filter against',
-              required=True)
-def run(scale, period, success_threshold, namespace, hpa_name, metric_name, deployment_name, part_of):
+@click.option('-f', '--filter-label', 'filter_label',
+              help='The metric label and value to filter against e.g. part-of=<app_name>')
+
+def run(scale, period, success_threshold, namespace, hpa_name, metric_name, deployment_name, filter_label):
 
 
     params = click.get_current_context().params

--- a/zero_scale/cli.py
+++ b/zero_scale/cli.py
@@ -33,7 +33,10 @@ click_log.basic_config(logger)
 @click.option('-d', '--deployment', 'deployment_name',
               default='default',
               help='The deployment to modify')
-def run(scale, period, success_threshold, namespace, hpa_name, metric_name, deployment_name):
+@click.option('-po', '--part-of', 'part_of',
+              help='The part_of value to filter against',
+              required=True)
+def run(scale, period, success_threshold, namespace, hpa_name, metric_name, deployment_name, part_of):
 
 
     params = click.get_current_context().params


### PR DESCRIPTION
## background
When multiple deployments in one namespace are using the same name for a prometheus metric - a value for each of those deployments will be returned in a list. 

## Problem:
*Occasionally the deployment will scale based on the wrong metric

## Solution:
*Introduce a filter argument for labels applied to the Prometheus metric by Kubernetes to ensure we scale on the correct one.


Example - Kubernetes applies the `part-of` label by default - if we supply the argument `--filter-label part-of=myapp1` we will only scale based on the prometheus metric supplied for that deployment.

Links;
https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/